### PR TITLE
Add Nebulo to Example Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ Expiry Date: Thursday, March 18, 2021
 ### Unbound
 
 [unbound.conf](example/unbound.conf)
+
+### Nebulo (Android App)
+
+The server is included in this app. [Download it](https://git.frostnerd.com/PublicAndroidApps/smokescreen), open the server list at the bottom right and select DNS.SB


### PR DESCRIPTION
I'm the developer of Nebulo, a [FOSS app](https://nebulo.app/source) for Android.
Nebulo allows devices with Android 5.0 and up to use DoH and DoT, bringing both protocols and a lot of other DNS related features to devices which don't support Private DNS (Android 9+).

DNS.SB is included into the app by default (both DoH and DoT), thus it would be awesome if Nebulo could be linked as a potential client for Android devices here.